### PR TITLE
Fix: Add polyfill for crypto.randomUUID in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,21 @@
+import { randomUUID } from 'crypto';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './all-exceptions.filter';
 import { join } from 'path';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import * as hbs from 'hbs';
+
+// Polyfill/ensure global crypto and randomUUID if not available
+// This is to mitigate "ReferenceError: crypto is not defined"
+// which can occur in some environments with @nestjs/schedule.
+if (typeof (global as any).crypto === 'undefined') {
+  (global as any).crypto = {
+    randomUUID: randomUUID
+  };
+} else if (typeof (global as any).crypto.randomUUID === 'undefined') {
+  (global as any).crypto.randomUUID = randomUUID;
+}
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {


### PR DESCRIPTION
Addresses "ReferenceError: crypto is not defined" by ensuring that global.crypto and global.crypto.randomUUID are available before the application bootstraps.

This issue typically arises in environments where the full Node.js crypto module might not be correctly exposed, affecting modules like @nestjs/schedule that rely on crypto.randomUUID().

The polyfill imports `randomUUID` from the 'crypto' module and assigns it to `global.crypto.randomUUID` if it's not already defined.